### PR TITLE
email share event listener send message via IONOS mail service

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -22,10 +22,12 @@ declare(strict_types=1);
 
 namespace OCA\IonosProcesses\AppInfo;
 
+use OCA\IonosProcesses\Listener\ShareCreatedEventListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Share\Events\ShareCreatedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'nc_ionos_processes';
@@ -36,6 +38,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerEventListener(ShareCreatedEvent::class, ShareCreatedEventListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Listener/ShareCreatedEventListener.php
+++ b/lib/Listener/ShareCreatedEventListener.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * SPDX-FileLicenseText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\IonosProcesses\Listener;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Notify customers about created shares via internal mail service.
+ */
+class ShareCreatedEventListener implements IEventListener {
+	public function __construct(
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof ShareCreatedEvent)) {
+			return;
+		}
+
+		$share = $event->getShare();
+		$shareType = $share->getShareType();
+
+		if ($shareType !== IShare::TYPE_EMAIL) {
+			$this->logger->debug('share type ' . $shareType . ' ignored');
+			return;
+		}
+
+		$this->logger->debug('share created for file ' . $share->getNode()->getName());
+	}
+}

--- a/lib/Listener/ShareCreatedEventListener.php
+++ b/lib/Listener/ShareCreatedEventListener.php
@@ -7,8 +7,13 @@
 
 namespace OCA\IonosProcesses\Listener;
 
+use OCA\IonosProcesses\Service\IonosMailerService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
@@ -17,8 +22,14 @@ use Psr\Log\LoggerInterface;
  * Notify customers about created shares via internal mail service.
  */
 class ShareCreatedEventListener implements IEventListener {
+	public const EVENT_NAME_SHARE_BY_LINK = 'share-by-link';
+
 	public function __construct(
-		private LoggerInterface $logger,
+		private readonly LoggerInterface $logger,
+		private readonly IUserManager $userManager,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly IonosMailerService $mailer,
 	) {
 	}
 
@@ -35,6 +46,41 @@ class ShareCreatedEventListener implements IEventListener {
 			return;
 		}
 
-		$this->logger->debug('share created for file ' . $share->getNode()->getName());
+		$user = $this->userManager->get($share->getSharedBy());
+
+		if ($user === null) {
+			$this->logger->error("can not find user for share with token '" . $share->getToken() . "'");
+			return;
+		}
+
+		try {
+			$filename = $share->getNode()->getName();
+		} catch (NotFoundException $e) {
+			$this->logger->error("can not find node for share with token '" . $share->getToken() . "': " . $e->getMessage());
+			return;
+		}
+
+		$language = $this->l10n->getLanguageCode();
+		$userId = $user->getUID();
+		$note = $share->getNote();
+		$expirationDate = $share->getExpirationDate();
+		$recipient = $share->getSharedWith();
+		$url = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', [
+			'token' => $share->getToken()
+		]);
+
+		$data = [
+			'senderUserId' => $userId,
+			'fileName' => $filename,
+			'resourceUrl' => $url,
+			'note' => $note,
+			'expirationDate' => $expirationDate?->getTimestamp(),
+			'language' => $language,
+			'receiverEmails' => [
+				$recipient,
+			]
+		];
+
+		$this->mailer->send(ShareCreatedEventListener::EVENT_NAME_SHARE_BY_LINK, $data);
 	}
 }

--- a/lib/Service/IonosMailerService.php
+++ b/lib/Service/IonosMailerService.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * SPDX-FileLicenseText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 namespace OCA\IonosProcesses\Service;
 
 /**

--- a/lib/Service/IonosMailerService.php
+++ b/lib/Service/IonosMailerService.php
@@ -17,8 +17,8 @@ class IonosMailerService {
 	/**
 	 * Send mails to the mail delivery web service
 	 *
-	 * @param string eventName name of the event
-	 * @param array associative array of variables to the mail service
+	 * @param string $eventName name of the event
+	 * @param array $associative array of variables to the mail service
 	 */
 	public function send(string $eventName, array $variables): void {
 		// Stub

--- a/tests/AppInfo/ApplicationTest.php
+++ b/tests/AppInfo/ApplicationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileLicenseText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\IonosProcesses\Tests\AppInfo;
+
+use OC\AppFramework\Bootstrap\Coordinator;
+use OCA\IonosProcesses\AppInfo\Application;
+use OCA\IonosProcesses\Listener\ShareCreatedEventListener;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Share\Events\ShareCreatedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationTest extends TestCase {
+	private Application $app;
+	private IRegistrationContext $context;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->app = new Application();
+		$coordinator = \OC::$server->get(Coordinator::class);
+		$this->app->register($coordinator->getRegistrationContext()->for('nc_ionos_processes'));
+		$this->context = $this->createMock(IRegistrationContext::class);
+	}
+
+	public function testRegisterCallsRegisterEventListenerOnContext(): void {
+		$this->context->expects($this->exactly(1))
+			->method('registerEventListener')
+			->with(
+				ShareCreatedEvent::class,
+				ShareCreatedEventListener::class,
+			);
+
+		$this->app->register($this->context);
+	}
+}

--- a/tests/Listener/ShareCreatedEventListenerTest.php
+++ b/tests/Listener/ShareCreatedEventListenerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileLicenseText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\IonosProcesses\Tests\Listener;
+
+use OCA\IonosProcesses\Listener\ShareCreatedEventListener;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Node;
+use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ShareCreatedEventListenerTest extends TestCase {
+	private LoggerInterface $mockLogger;
+	private ShareCreatedEvent $mockEvent;
+	private IShare $mockShare;
+	private Node $mockNode;
+
+	private ShareCreatedEventListener $listener;
+
+	protected function setUp(): void {
+		$this->mockLogger = $this->getMockBuilder(LoggerInterface::class)
+			->getMock();
+
+		$this->mockNode = $this->getMockBuilder(Node::class)
+			->getMock();
+
+		$this->mockShare = $this->getMockBuilder(IShare::class)
+			->getMock();
+
+		$this->mockEvent = $this->getMockBuilder(ShareCreatedEvent::class)
+			->setConstructorArgs([$this->mockShare])
+			->getMock();
+
+		$this->mockEvent
+			->method('getShare')
+			->willReturn($this->mockShare);
+
+		$this->listener = new ShareCreatedEventListener($this->mockLogger);
+	}
+
+	public function testNonShareTypeEmailShallBeIgnored(): void {
+		$this->expectNotToPerformAssertions();
+
+		$this->mockShare
+			->method('getShareType')
+			->willReturnOnConsecutiveCalls(
+				IShare::TYPE_USER,
+				IShare::TYPE_GROUP,
+				IShare::TYPE_USERGROUP,
+				IShare::TYPE_LINK,
+			);
+
+		$this->mockLogger
+			->method('debug')
+			->will($this->onConsecutiveCalls(
+				'share type ' . IShare::TYPE_USER . ' ignored',
+				'share type ' . IShare::TYPE_GROUP . ' ignored',
+				'share type ' . IShare::TYPE_USERGROUP . ' ignored',
+				'share type ' . IShare::TYPE_LINK . ' ignored',
+			));
+
+
+		// Four calls for the event types
+		$this->listener->handle($this->mockEvent);
+		$this->listener->handle($this->mockEvent);
+		$this->listener->handle($this->mockEvent);
+		$this->listener->handle($this->mockEvent);
+	}
+
+	public function testShareTypeEmailShallHandled(): void {
+		$mockNodeName = 'mock-name';
+
+		$this->mockNode
+			->method('getName')
+			->willReturn($mockNodeName);
+
+		$this->mockShare
+			->method('getShareType')
+			->willReturn(IShare::TYPE_EMAIL);
+
+		$this->mockShare
+			->method('getNode')
+			->willReturn($this->mockNode);
+
+		$this->mockLogger->expects($this->exactly(1))
+			->method('debug')
+			->with(
+				'share created for file ' . $mockNodeName,
+			);
+
+		$this->listener->handle($this->mockEvent);
+	}
+}

--- a/tests/Listener/ShareCreatedEventListenerTest.php
+++ b/tests/Listener/ShareCreatedEventListenerTest.php
@@ -9,18 +9,43 @@ declare(strict_types=1);
 
 namespace OCA\IonosProcesses\Tests\Listener;
 
+use DateTime;
 use OCA\IonosProcesses\Listener\ShareCreatedEventListener;
+use OCA\IonosProcesses\Service\IonosMailerService;
 use OCP\EventDispatcher\Event;
 use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\IShare;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Enum to write expressive, speaking boolean in test config.
+ */
+enum UserIs {
+	case FOUND;
+	case NOT_FOUND;
+}
+
 class ShareCreatedEventListenerTest extends TestCase {
+	public const MOCK_USER_ID = '123e4567-e89b-12d3-a456-426614174000';
+	public const MOCK_SHARE_TOKEN = 'mock-token';
+	public const MOCK_NOTE = 'mock-note';
+	public const MOCK_RECIPIENT = 'mock-recipient';
 	private LoggerInterface $mockLogger;
+	private IUserManager $mockUserManager;
+	private IUser $mockUser;
+	private IonosMailerService $mockMailer;
+	private IL10N $mockL10N;
+	private IURLGenerator $mockUrlGenerator;
 	private ShareCreatedEvent $mockEvent;
 	private IShare $mockShare;
+	private DateTime $mockTimestamp;
 	private Node $mockNode;
 
 	private ShareCreatedEventListener $listener;
@@ -29,7 +54,32 @@ class ShareCreatedEventListenerTest extends TestCase {
 		$this->mockLogger = $this->getMockBuilder(LoggerInterface::class)
 			->getMock();
 
+		$this->mockUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mockUserManager = $this->getMockBuilder(IUserManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mockMailer = $this->getMockBuilder(IonosMailerService::class)
+			->onlyMethods([
+				'send',
+			])
+			->getMock();
+
+		$this->mockL10N = $this->getMockBuilder(IL10N::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mockUrlGenerator = $this->getMockBuilder(IURLGenerator::class)
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->mockNode = $this->getMockBuilder(Node::class)
+			->getMock();
+
+		$this->mockTimestamp = $this->getMockBuilder(\DateTime::class)
 			->getMock();
 
 		$this->mockShare = $this->getMockBuilder(IShare::class)
@@ -43,7 +93,13 @@ class ShareCreatedEventListenerTest extends TestCase {
 			->method('getShare')
 			->willReturn($this->mockShare);
 
-		$this->listener = new ShareCreatedEventListener($this->mockLogger);
+		$this->listener = new ShareCreatedEventListener(
+			$this->mockLogger,
+			$this->mockUserManager,
+			$this->mockL10N,
+			$this->mockUrlGenerator,
+			$this->mockMailer,
+		);
 	}
 
 	public function testNonShareTypeEmailShallBeIgnored(): void {
@@ -75,8 +131,46 @@ class ShareCreatedEventListenerTest extends TestCase {
 		$this->listener->handle($this->mockEvent);
 	}
 
-	public function testShareTypeEmailShallHandled(): void {
+	private function configureMocks(
+		UserIs $userFound,
+		string $mockLanguageCode,
+		?int $mockExpiration,
+	): void {
+		$mockUserId = '123e4567-e89b-12d3-a456-426614174000';
 		$mockNodeName = 'mock-name';
+		$mockUrl = 'mock-url';
+
+		$this->mockL10N
+			->method('getLanguageCode')
+			->willReturn($mockLanguageCode);
+
+		if ($userFound == UserIs::FOUND) {
+			$this->mockUser
+				->method('getUID')
+				->willReturn(ShareCreatedEventListenerTest::MOCK_USER_ID);
+
+			$this->mockUserManager
+				->method('get')
+				->willReturn($this->mockUser);
+		} else {
+			$this->mockUserManager
+				->method('get')
+				->willReturn(null);
+		}
+
+		$this->mockUserManager
+			->method('get')
+			->willReturn($mockUserId);
+
+		$this->mockUrlGenerator
+			->method('linkToRouteAbsolute')
+			->with(
+				'files_sharing.sharecontroller.showShare',
+				[
+					'token' => ShareCreatedEventListenerTest::MOCK_SHARE_TOKEN,
+				],
+			)
+			->willReturn($mockUrl);
 
 		$this->mockNode
 			->method('getName')
@@ -90,11 +184,141 @@ class ShareCreatedEventListenerTest extends TestCase {
 			->method('getNode')
 			->willReturn($this->mockNode);
 
-		$this->mockLogger->expects($this->exactly(1))
-			->method('debug')
+		$this->mockShare
+			->method('getToken')
+			->willReturn(ShareCreatedEventListenerTest::MOCK_SHARE_TOKEN);
+
+		$this->mockShare
+			->method('getSharedWith')
+			->willReturn(ShareCreatedEventListenerTest::MOCK_RECIPIENT);
+
+		$this->mockShare
+			->method('getNote')
+			->willReturn(ShareCreatedEventListenerTest::MOCK_NOTE);
+
+		if ($mockExpiration !== null) {
+			$this->mockShare
+				->method('getExpirationDate')
+				->willReturn($this->mockTimestamp);
+
+			$this->mockTimestamp
+				->method('getTimestamp')
+				->willReturn($mockExpiration);
+		} else {
+			$this->mockShare
+				->method('getExpirationDate')
+				->willReturn(null);
+		}
+	}
+
+	public function testShareTypeEmailNoExpirationDate(): void {
+		$mockLanguageCode = 'lang_LOCALE';
+		$mockNodeName = 'mock-name';
+		$mockUrl = 'mock-url';
+		$mockExpiration = null;
+
+		$this->configureMocks(
+			UserIs::FOUND,
+			$mockLanguageCode,
+			$mockExpiration,
+		);
+
+		$this->mockMailer
+			->expects($this->exactly(1))
+			->method('send')
 			->with(
-				'share created for file ' . $mockNodeName,
+				ShareCreatedEventListener::EVENT_NAME_SHARE_BY_LINK,
+				[
+					'senderUserId' => ShareCreatedEventListenerTest::MOCK_USER_ID,
+					'fileName' => $mockNodeName,
+					'resourceUrl' => $mockUrl,
+					'note' => ShareCreatedEventListenerTest::MOCK_NOTE,
+					'expirationDate' => $mockExpiration,
+					'language' => $mockLanguageCode,
+					'receiverEmails' => [
+						ShareCreatedEventListenerTest::MOCK_RECIPIENT,
+					]
+				]
 			);
+
+		$this->listener->handle($this->mockEvent);
+	}
+
+	public function testShareTypeEmailHasExpirationDate(): void {
+		$mockLanguageCode = 'lang_LOCALE';
+		$mockNodeName = 'mock-name';
+		$mockUrl = 'mock-url';
+		$mockExpiration = 123456789;
+
+		$this->configureMocks(
+			UserIs::FOUND,
+			$mockLanguageCode,
+			$mockExpiration,
+		);
+
+		$this->mockMailer
+			->expects($this->exactly(1))
+			->method('send')
+			->with(
+				ShareCreatedEventListener::EVENT_NAME_SHARE_BY_LINK,
+				[
+					'senderUserId' => ShareCreatedEventListenerTest::MOCK_USER_ID,
+					'fileName' => $mockNodeName,
+					'resourceUrl' => $mockUrl,
+					'note' => ShareCreatedEventListenerTest::MOCK_NOTE,
+					'expirationDate' => $mockExpiration,
+					'language' => $mockLanguageCode,
+					'receiverEmails' => [
+						ShareCreatedEventListenerTest::MOCK_RECIPIENT,
+					]
+				]
+			);
+
+		$this->listener->handle($this->mockEvent);
+	}
+
+	public function testShareTypeEmailUserNotFound(): void {
+		$mockLanguageCode = 'lang_LOCALE';
+		$mockExpiration = 123456789;
+
+		$this->configureMocks(
+			UserIs::NOT_FOUND,
+			$mockLanguageCode,
+			$mockExpiration,
+		);
+
+		$this->mockMailer
+			->expects($this->exactly(0))
+			->method('send');
+
+		$this->mockLogger
+			->method('error')
+			->with("can not find user for share with token '" . ShareCreatedEventListenerTest::MOCK_SHARE_TOKEN . "'");
+
+		$this->listener->handle($this->mockEvent);
+	}
+
+	public function testShareTypeEmailNodeNotFound(): void {
+		$mockLanguageCode = 'lang_LOCALE';
+		$mockExpiration = 123456789;
+
+		$this->mockShare
+			->method('getNode')
+			->willThrowException(new NotFoundException('node not found'));
+
+		$this->configureMocks(
+			UserIs::FOUND,
+			$mockLanguageCode,
+			$mockExpiration,
+		);
+
+		$this->mockMailer
+			->expects($this->exactly(0))
+			->method('send');
+
+		$this->mockLogger
+			->method('error')
+			->with("can not find node for share with token '" . ShareCreatedEventListenerTest::MOCK_SHARE_TOKEN . "': node not found");
 
 		$this->listener->handle($this->mockEvent);
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,5 +5,5 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../../tests/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
-\OC_App::loadApp(OCA\NcTheming\AppInfo\Application::APP_ID);
+\OC_App::loadApp(OCA\IonosProcesses\AppInfo\Application::APP_ID);
 OC_Hook::clear();


### PR DESCRIPTION
## Prerequisites

```
$ ./occ app:enable sharebymail
```

This was already changed in the config repo.

## Build

```
apps-custom/nc_ionos_processes $ composer install
```

## App-Install

```
$ ./occ app:enable nc_ionos_processes
```

## Inspect logs

```
apps-custom/nc_ionos_processes $ tail -f data/nextcloud.log | grep --line-buffered '"app":"nc_ionos_processes"' | jq -r .message
```

You should see a message like this:

```
share-by-link = {"senderUserId":"ebf4d345-1408-4974-83a0-42f461015672","fileName":"foo","resourceUrl":"http:\/\/localhost:8080\/index.php\/s\/NeLagakC3TXTqgN","note":"foo","expirationDate":1729641600,"language":"en","receiverEmails":["fooo@acme.com"]}
```